### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "meanbee/royalmail",
+    "type": "magento-module",
+    "description": "A Magento shipping extension to add Royal Mail shipping methods.",
+    "homepage": "https://www.meanbee.com/magento-extensions/magento-royal-mail.html"
+}


### PR DESCRIPTION
The composer.json file will mean that the extension can be installed using https://github.com/Cotya/magento-composer-installer

Replaces https://github.com/meanbee/royalmail/pull/29