### PR TITLE
#42: Inconsistent spelling royal mail in library classes

### DIFF
--- a/lib/Meanbee/RoyalmailPHPLibrary/composer.json
+++ b/lib/Meanbee/RoyalmailPHPLibrary/composer.json
@@ -9,6 +9,6 @@
   },
 
   "autoload": {
-    "psr-4": { "Meanbee\\RoyalMail\\": ["src/", "tests/"] }
+    "psr-4": { "Meanbee\\Royalmail\\": ["src/", "tests/"] }
   }
 }

--- a/lib/Meanbee/RoyalmailPHPLibrary/src/CalculateMethod.php
+++ b/lib/Meanbee/RoyalmailPHPLibrary/src/CalculateMethod.php
@@ -56,7 +56,7 @@ class Meanbee_RoyalmailPHPLibrary_CalculateMethod
 
         foreach ($sortedDeliveryMethods as $shippingMethod) {
             foreach ($shippingMethod as $item) {
-                $method = new Meanbee_RoyalMailPHPLibrary_src_Method();
+                $method = new Meanbee_RoyalmailPHPLibrary_src_Method();
                 $method->countryCode = $country_code;
                 $method->shippingMethodName = $item['shippingMethodName'];
                 $method->minimumWeight = $item['minimumWeight'];

--- a/lib/Meanbee/RoyalmailPHPLibrary/src/Method.php
+++ b/lib/Meanbee/RoyalmailPHPLibrary/src/Method.php
@@ -1,6 +1,6 @@
 <?php
 
-class Meanbee_RoyalMailPHPLibrary_src_Method
+class Meanbee_RoyalmailPHPLibrary_src_Method
 {
     // The shipping code name of the method
     public $shippingMethodName;

--- a/lib/Meanbee/RoyalmailPHPLibrary/tests/RoyalmailTest.php
+++ b/lib/Meanbee/RoyalmailPHPLibrary/tests/RoyalmailTest.php
@@ -105,7 +105,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
     /**
      * Test to ensure that the calculate method class is returning
      */
-    public function testRoyalMailClassRealValues()
+    public function testRoyalmailClassRealValues()
     {
         $this->assertNotEmpty($this->calculateMethodClass->getMethods('GB', 20, 0.050));
     }
@@ -113,7 +113,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
     /**
      * Test to compare the returned data from the Data class to expected values
      */
-    public function testRoyalMailMethodRealValues()
+    public function testRoyalmailMethodRealValues()
     {
         $this->assertEquals($this->testDataClassArray, $this->dataClass->calculateMethods('GB', 19.99, 0.050));
     }
@@ -121,7 +121,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
     /**
      * Test to ensure the only the expected empty array is returned from incorrect data to the data class
      */
-    public function testRoyalMailMethodFake()
+    public function testRoyalmailMethodFake()
     {
         $this->assertEquals($this->emptyArray, $this->dataClass->calculateMethods('GASD', "aSDASD", "ASDASD"));
         $this->assertEquals($this->emptyArray, $this->dataClass->calculateMethods(123123123, "asdasd", "asdadasd"));
@@ -135,7 +135,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
      * Test to ensure that only the expected empty array is returned from null and incorrect data
      * from the Data class
      */
-    public function testRoyalMailMethodNull()
+    public function testRoyalmailMethodNull()
     {
         $this->assertEquals($this->emptyArray, $this->dataClass->calculateMethods(null, 123123123123, 0.100));
         $this->assertEquals($this->emptyArray, $this->dataClass->calculateMethods(null, null, 0.100));
@@ -149,7 +149,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
      * Test to ensure that only the expected empty array is returned from incorrect
      * data from the CalculateMethod class
      */
-    public function testRoyalMailClassFake()
+    public function testRoyalmailClassFake()
     {
         $this->assertEquals(
             $this->emptyArray,
@@ -175,7 +175,7 @@ class Meanbee_RoyalmailPHPLibrary_tests_RoyalmailTest extends PHPUnit_Framework_
      * Test to ensure that only the expected empty array is returned from null
      * and incorrect data from the CalculateMethod class
      */
-    public function testRoyalMailClassNull()
+    public function testRoyalmailClassNull()
     {
         $this->assertEquals($this->emptyArray, $this->calculateMethodClass->getMethods(null, 123123123123, 0.100));
         $this->assertEquals($this->emptyArray, $this->calculateMethodClass->getMethods(null, null, 0.100));


### PR DESCRIPTION
Royal mail is sometimes incorrectly spelled with a capital and has been changed to be "Royalmail" instead of "RoyalMail"