### PR TITLE
#48: PHP 5.3 Incorrect use of Array[] in CalculateMethod Class in Roy…

### DIFF
--- a/app/code/community/Meanbee/Royalmail/etc/config.xml
+++ b/app/code/community/Meanbee/Royalmail/etc/config.xml
@@ -22,7 +22,7 @@
 <config>
     <modules>
         <Meanbee_Royalmail>
-            <version>2.7.0</version>
+            <version>2.7.2</version>
             <depends>
                 <Mage_Shipping />
             </depends>

--- a/lib/Meanbee/RoyalmailPHPLibrary/src/CalculateMethod.php
+++ b/lib/Meanbee/RoyalmailPHPLibrary/src/CalculateMethod.php
@@ -52,7 +52,7 @@ class Meanbee_RoyalmailPHPLibrary_CalculateMethod
 
         $sortedDeliveryMethods = array($data->calculateMethods($country_code, $package_value, $package_weight));
 
-        $results = [];
+        $results = array();
 
         foreach ($sortedDeliveryMethods as $shippingMethod) {
             foreach ($shippingMethod as $item) {

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <_>
-   <form_key>QwJX3XS3dAhahdvS</form_key>
+   <form_key>y0ShjLGrOcqkOAlh</form_key>
    <name>Meanbee_Royalmail</name>
    <channel>community</channel>
    <version_ids>
@@ -9,13 +9,9 @@
    <description>Automatically calculated Royal Mail delivery methods.</description>
    <license>Open Software License v3.0 (OSL-3.0)</license>
    <license_uri>http://www.opensource.org/licenses/osl-3.0.php</license_uri>
-   <version>2.7.1</version>
+   <version>2.7.2</version>
    <stability>stable</stability>
-   <notes>*Added additional Royalmail shipping methods
-
-*Fixed incorrect name error
-
-*Fixed PHP 5.4 and lower error</notes>
+   <notes>* Fixed PHP 5.3 error</notes>
    <authors>
       <name>
          <name>Meanbee</name>
@@ -27,7 +23,7 @@
          <email>hello@meanbee.com</email>
       </email>
    </authors>
-   <depends_php_min>5.2.0</depends_php_min>
+   <depends_php_min>5.3.0</depends_php_min>
    <depends_php_max>7.1.0</depends_php_max>
    <depends>
       <package>
@@ -44,7 +40,7 @@
             <max/>
          </max>
          <files>
-            <files>                      </files>
+            <files>                       </files>
          </files>
       </package>
       <extension>


### PR DESCRIPTION
…almail PHP Library and Update Package for Magento Connect

Fixed the usage of Array[] in the Royalmail PHP Library to be Array(). This should resolve a bug in php 5.3. Also update the package info for Magento Connect to release new version.